### PR TITLE
App driven workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This document describes the workflow we use for Data Rescue activites as develop
 We are so glad that you are participating in this project!
 
 **[If you are an overall Coordinator](coordinator-work.md)**:
-- See the description of some of the work overall coordinators do, including the role of the Spreadsheet Minder, [here](coordinator-work.md)
+- See the description of some of the work overall coordinators do [here](coordinator-work.md)
 
 **[If you are an Event Organizer](advance-work.md)**:
 - Learn about what you need to do to prepare the event [here](advance-work.md).
 
 **If you are a regular participant**: 
-- Get a role assignment (e.g., Seeder, or Harvester), get account credentials needed for your role, and make sure you have access to the key documents and spreadsheets needed to do the work. The Event/Remote organizers will tell you how proceed to do all this. 
+- Get a role assignment (e.g., Seeder, or Harvester), get account credentials needed for your role, and make sure you have access to the key documents and app needed to do the work. The Event/Remote organizers will tell you how proceed to do all this. 
 - Go over the workflow documentation below, in particular the pages corresponding to your role.
 
 **********************

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Checkers inspect a harvested dataset and make sure that it is complete. The main
 Baggers do some quality assurance on the dataset to make sure the content is correct and corresponds to what was described in the spreadsheet. Then they package the data into a bagit file (or "bag"), which includes basic technical metadata and upload it to final DataRefuge destination.
 
 ### 7. Describers
-<1--[Describers](metadata.md)-->
+<!--[Describers](metadata.md)-->
 Describers creates a descriptive record in the DataRefuge CKAN repository for each bag. Then they links the record to the bag, and make the record public
 **Note: This role is currently being redeveloped and is not currently active.**
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Baggers do some quality assurance on the dataset to make sure the content is cor
 
 ### 7. Describers
 <!--[Describers](metadata.md)-->
-Describers creates a descriptive record in the DataRefuge CKAN repository for each bag. Then they links the record to the bag, and make the record public
+Describers creates a descriptive record in the DataRefuge CKAN repository for each bag. Then they links the record to the bag, and make the record public.
+
 **Note: This role is currently being redeveloped and is not currently active.**
 
 **********************

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Baggers do some quality assurance on the dataset to make sure the content is cor
 
 ### 7. Describers
 <!--[Describers](metadata.md)-->
-Describers creates a descriptive record in the DataRefuge CKAN repository for each bag. Then they links the record to the bag, and make the record public.
 
 **Note: This role is currently being redeveloped and is not currently active.**
+
+Describers creates a descriptive record in the DataRefuge CKAN repository for each bag. Then they links the record to the bag, and make the record public.
 
 **********************
 ## Partners

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This document describes the workflow we use for Data Rescue activites as develop
 ## Before you begin
 We are so glad that you are participating in this project!
 
-**[If you are an overall Coordinator](coordinator-work.md)**:
-- See the description of some of the work overall coordinators do [here](coordinator-work.md)
+<!--**[If you are an overall Coordinator](coordinator-work.md)**:
+- See the description of some of the work overall coordinators do [here](coordinator-work.md)-->
 
 **[If you are an Event Organizer](advance-work.md)**:
 - Learn about what you need to do to prepare the event [here](advance-work.md).

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Checkers inspect a harvested dataset and make sure that it is complete. The main
 ### 5. [Baggers](bagging.md)
 Baggers do some quality assurance on the dataset to make sure the content is correct and corresponds to what was described in the spreadsheet. Then they package the data into a bagit file (or "bag"), which includes basic technical metadata and upload it to final DataRefuge destination.
 
-
-### 7. [Describers](metadata.md)
+### 7. Describers
+<1--[Describers](metadata.md)-->
 Describers creates a descriptive record in the DataRefuge CKAN repository for each bag. Then they links the record to the bag, and make the record public
+**Note: This role is currently being redeveloped and is not currently active.**
+
 **********************
 ## Partners
 Data Rescue is a broad, grassroots effort with support from numerous local and nationwide networks. [DateRefuge](http://www.ppehlab.org/datarefuge/) thanks [EDGI](https://envirodatagov.org/) in particular for their contributions, and to our numerous supporters for their hard work. See more of our institutional partners on our [home page](http://www.ppehlab.org/datarefuge#partners).

--- a/advance-work.md
+++ b/advance-work.md
@@ -21,21 +21,28 @@ Before starting, your team should go through the following steps.
 - Those are documents that will inform the work of the Seeders/Sorters at your event. They will tell them which website or website sections they should be focusing on for URL discovery. 
 - An EDGI coordinator will setup these documents for you.
 
-## Uncrawlable Action spreadsheet
-- Make sure your event also has its designated Uncrawlable Action spreadsheet. This is a spreadsheet listing a maximum of 500 URLs that have been identified as unscrawlable and will have to be harvested manually or semi-manually.
-  - A DataRefuge coordinator will prepare that spreadsheet for you so that it is ready to use on the day of the event.
-  - The spreadsheet will help keep track of which URLs have already been archived and which ones have not
-  - It will also help coordinate the work of different roles (Researchers, Harvesters, Checkers, Baggers, Describers) on each URL.
-- The spreadsheet will include URLs coming from two main sources:
+## Archivers app
+- The [Archivers app](http://www.archivers.space/) enables us to collectively keep track of all the archiving work being done.
+ - It will also help coordinate the work of different roles (Researchers, Harvesters, Checkers, Baggers, Describers) on each URL.
+- The app will include URLs coming from two main sources:
    - URLs that were nominated by Seeders at a previous DataRescue event, 
    - URLs that were identified througth the Union of Concerned Scientists survey, which asked the scientific community to list the most vulnerable and important data currently on accessible through federal websites. 
+   
+- You need to make sure that:
+  - Your event is listed in the app.
+  - All the event participants who need it have access to the app (see Credentials section below)
+    - And that they "join" your event inside the app 
 
 ## Crawl vs. Harvest: storage needs 
 - The main triage point of the workflow is whether a URL can be automatically crawled, for instance by the Internet Archive, or whether it  needs to be manually harvested. 
 - The crawling process does not require any separate storage management, as the crawlable URLs are nominated to the Internet Archive, who will take care of the actual file storage after they have crawled the pages. See the [Seeders/Sorters documentation](seednsort.md) for more information on this process. 
  - The datasets harvested through the harvest process are stored on S3 storage managed directly by DataRefuge.
+   - Datasets uploaded through the Archivers app are automatically uploaded to S3
 
 ## S3 storage
+- While the file storage process is streamlined and "invisible" to the event participants, as an organizer you should still make sure that the storage has been set up properly for your event.
+- Talk to the DataRefuge organizers about this.
+<!--
 - You need two S3 "buckets" (i.e., directories) for your harvested files.  
  - The Harvesters will upload the files they harvest to the first bucket ("pre-bag" bucket)
   - In some cases, the Checkers will also upload improved versions of the files to the same pre-bag bucket
@@ -47,17 +54,14 @@ Before starting, your team should go through the following steps.
   - Upload very large sets (beyond 5 Gigs) through an alternate method (provided by DataRefuge)
   - Keep the buckets cleaned up and organized. 
 - Note that large files Uploaders need not be coders, but they should have a little experience working in command line, and computers with python 2.7.
+-->
   
 ## Credentials
-- Specific roles need special credentials:
-  - The Harvesters/Checkers need **credentials for [their version of the uploader](http://drp-upload.herokuapp.com)**
-  - The Baggersneed **credentials for [their version of the uploader](http://drp-upload-bagger.herokuapp.com)**
-  - The Describers (Ckan/Metadata folks) need **credentials for [ckan](https://www.datarefuge.org/)**. 
-  - The S3 System Administrator needs **credentials for s3**. 
-- Access to the Unscrawlable spreadsheet:
-  - Each Checker/Bagger/Describer needs to be given write access to the tab corresponding to their role in the Unscrawlable Action spreadsheet
-  - The Researchers/Harvesters tab is accessible in free access
-  - Seeders/Sorters do not need access to the spreadsheet
+- The Researchers/Harvesters/Checkers/Baggers need to have an account on the [Archivers app](http://www.archivers.space/) 
+- Checkers and Baggers need to be given explicit privileges in the app to have access to the Checking (i.e. "Finalize") and Bagging sections. 
+- Seeders/Sorters do not need access to the Archivers app.
+<!--  - The Describers (Ckan/Metadata folks) need **credentials for [ckan](https://www.datarefuge.org/)**. -->
+<!--- The S3 System Administrator needs credentials for s3. -->
 
 ## Other supplies
 Make sure you have a few thumb drives to handle very large data sets (above 5 Gigs).

--- a/advance-work.md
+++ b/advance-work.md
@@ -31,7 +31,7 @@ Before starting, your team should go through the following steps.
 - You need to make sure that:
   - Your event is listed in the app.
   - All the event participants who need it have access to the app (see Credentials section below)
-    - And that they "join" your event inside the app 
+  
 
 ## Crawl vs. Harvest: storage needs 
 - The main triage point of the workflow is whether a URL can be automatically crawled, for instance by the Internet Archive, or whether it  needs to be manually harvested. 
@@ -57,6 +57,8 @@ Before starting, your team should go through the following steps.
   
 ## Credentials
 - The Researchers/Harvesters/Checkers/Baggers need to have an account on the [Archivers app](http://www.archivers.space/) 
+  - You will need to generate invites for each one [within the app](http://www.archivers.space/invites/new), and paste the URL generated in a slack Direct Message or an email.
+  - Each participant invited will automatically "belong" to your event in the app.
 - Checkers and Baggers need to be given explicit privileges in the app to have access to the Checking (i.e. "Finalize") and Bagging sections. 
 - Seeders/Sorters do not need access to the Archivers app.
 <!--  - The Describers (Ckan/Metadata folks) need **credentials for [ckan](https://www.datarefuge.org/)**. -->

--- a/advance-work.md
+++ b/advance-work.md
@@ -42,8 +42,8 @@ Before starting, your team should go through the following steps.
 ## S3 storage
 - While the file storage process is streamlined and "invisible" to the event participants, as an organizer you should still make sure that the storage has been set up properly for your event.
 - Talk to the DataRefuge organizers about this.
-<!--
-- You need two S3 "buckets" (i.e., directories) for your harvested files.  
+
+<!-- - You need two S3 "buckets" (i.e., directories) for your harvested files.  
  - The Harvesters will upload the files they harvest to the first bucket ("pre-bag" bucket)
   - In some cases, the Checkers will also upload improved versions of the files to the same pre-bag bucket
  - The Baggers will turn those files into bags and upload the bags to the second bucket ("bag" bucket)
@@ -53,8 +53,7 @@ Before starting, your team should go through the following steps.
  - One person at the event should be designated as the S3 System Administrator and will have direct access to the S3 buckets for the event. The S3 Sys Admin should be someone with advanced technical skills and will be responsible for 2 things:
   - Upload very large sets (beyond 5 Gigs) through an alternate method (provided by DataRefuge)
   - Keep the buckets cleaned up and organized. 
-- Note that large files Uploaders need not be coders, but they should have a little experience working in command line, and computers with python 2.7.
--->
+- Note that large files Uploaders need not be coders, but they should have a little experience working in command line, and computers with python 2.7.-->
   
 ## Credentials
 - The Researchers/Harvesters/Checkers/Baggers need to have an account on the [Archivers app](http://www.archivers.space/) 

--- a/advance-work.md
+++ b/advance-work.md
@@ -16,6 +16,8 @@ Before starting, your team should go through the following steps.
 - The event organizers and team leaders should schedule a call with DataRefuge to go over the process. 
 - The event organizers and team leaders for the Seeders and Sorters should also check in with EDGI folks for info about how to make sure that you're seeding and sorting effectively. 
 
+**Note that the Describers role is being redeveloped at the moment, so it is currently not enabled.**
+
 ## Primer and sub-primer documents
 - Make sure your event has its designated primer and sub-primer documents
 - Those are documents that will inform the work of the Seeders/Sorters at your event. They will tell them which website or website sections they should be focusing on for URL discovery. 
@@ -30,18 +32,18 @@ Before starting, your team should go through the following steps.
    
 - You need to make sure that:
   - Your event is listed in the app.
+    - Talk to the DataRefuge organizers about this.
   - All the event participants who need it have access to the app (see Credentials section below)
   
-
-## Crawl vs. Harvest: storage needs 
+## Crawl vs. Harvest: storage location 
 - The main triage point of the workflow is whether a URL can be automatically crawled, for instance by the Internet Archive, or whether it  needs to be manually harvested. 
 - The crawling process does not require any separate storage management, as the crawlable URLs are nominated to the Internet Archive, who will take care of the actual file storage after they have crawled the pages. See the [Seeders/Sorters documentation](seednsort.md) for more information on this process. 
- - The datasets harvested through the harvest process are stored on S3 storage managed directly by DataRefuge.
-   - Datasets uploaded through the Archivers app are automatically uploaded to S3
+- The datasets harvested through the harvest process and uploaded through are the Archivers app are stored on S3 storage managed by DataRefuge.
+- At this time there is no direct access to the files stored on S3 for security reason.
 
-## S3 storage
+<!--## S3 storage
 - While the file storage process is streamlined and "invisible" to the event participants, as an organizer you should still make sure that the storage has been set up properly for your event.
-- Talk to the DataRefuge organizers about this.
+- Talk to the DataRefuge organizers about this.-->
 
 <!-- - You need two S3 "buckets" (i.e., directories) for your harvested files.  
  - The Harvesters will upload the files they harvest to the first bucket ("pre-bag" bucket)
@@ -58,9 +60,9 @@ Before starting, your team should go through the following steps.
 ## Credentials
 - The Researchers/Harvesters/Checkers/Baggers need to have an account on the [Archivers app](http://www.archivers.space/) 
   - You will need to generate invites for each one [within the app](http://www.archivers.space/invites/new), and paste the URL generated in a slack Direct Message or an email.
-  - Each participant invited will automatically "belong" to your event in the app.
+  - Each participant invited will automatically "belongs" to your event in the app.
 - Checkers and Baggers need to be given explicit privileges in the app to have access to the Checking (i.e. "Finalize") and Bagging sections. 
-- Seeders/Sorters do not need access to the Archivers app.
+- Seeders/Sorters do not need access to the Archivers app. 
 <!--  - The Describers (Ckan/Metadata folks) need **credentials for [ckan](https://www.datarefuge.org/)**. -->
 <!--- The S3 System Administrator needs credentials for s3. -->
 

--- a/bagging.md
+++ b/bagging.md
@@ -89,6 +89,7 @@ The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to 
 - To ensure that the bag was uploaded successfully, go to the URL and download the bag back to your laptop.
 - Unzip it, open it and spot check to make sure that the bag looks well formed and the files seem valid.
 
-- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- In the Archivers app, make sure to fill out as much information as possible to document your work.
 - Check the Bag checkbox (on the right-hand side) to mark that step as completed. 
+- Click `Save`.
 - Click `Check in URL`, to release it and allow someone else to work on the next step. 

--- a/bagging.md
+++ b/bagging.md
@@ -4,29 +4,33 @@
 Baggers do some quality assurance on the dataset to make sure the content is correct and corresponds to what was described in the spreadsheet. Then they package the data into a bagit file (or "bag"), which includes basic technical metadata and upload it to final DataRefuge destination.
 
 ## Getting set up as a Bagger
-  - Apply to become a Bagger 
-    - By asking your DataRescue guide or by filling out [this form](https://docs.google.com/a/temple.edu/forms/d/e/1FAIpQLSfh9YIFnDrc-Cuc0hTd-U37J3D8xw8K7VXmzWkPs6Y5Q0wfVg/viewform)
-    - Skills recommended: in general, Baggers need to have some tech skills and a good understanding of harvesting goals.
+- Skills recommended for this role: in general, Baggers need to have some tech skills and a good understanding of harvesting goals.
+- Apply to become a Bagger 
+   - By filling out [this form](https://docs.google.com/a/temple.edu/forms/d/e/1FAIpQLSfh9YIFnDrc-Cuc0hTd-U37J3D8xw8K7VXmzWkPs6Y5Q0wfVg/viewform) 
     - Note that an email address is required to apply.
     - Note also that you should be willing to have your real name be associated with the datasets, to follow archival best practices (see [guidelines on archival best practices for Data Refuge](http://www.ppehlab.org/blogposts/2017/2/1/data-refuge-rests-on-a-clear-chain-of-custody) for more information).
-  - Credentials, slack invite, Uncrawlable spreadsheet URL, and other details will be provided once your application is approved.
-  - Test the Uploader application http://drp-upload-bagger.herokuapp.com with the credentials provided
-      - Make sure to select the right event in the dropdown
-  - Verify that you have write access to the #Baggers tab in the Uncrawlable spreadsheet
-  - Get set up with Python and the Python script to make a bag at the command line https://github.com/LibraryOfCongress/bagit-python
-  - If you need any assistance:
-      - Talk to your DataRescue Guide if you are at an in-person event
-      - Or post questions on Slack in the #Baggers channel.
+- The organizers of the event (in-person or remote) will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
+	- Click the invite link, and choose a user name and a password.    
+- Make sure you have an account on the DataRefuge slack where people share expertise and answer each other's questions.
+	- Ask your event organizer to send you an invite 
+- Get set up with Python and the Python script to make a bag at the command line https://github.com/LibraryOfCongress/bagit-python
+- If you need any assistance:
+  - Talk to your DataRescue Guide if you are at an in-person event
+  - Or post questions on Slack in the #Baggers channel.
+  
+  
+## Note: URL vs UUID
+The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
+
   
 ## Claiming a dataset for bagging
-  - You will work on datasets that were harvested by Checkers. 
-  - Go to the Uncrawlable spreadsheet, click the Baggers tab, and look for a dataset to check
-    - Available datasets are the ones whose cell "Baggers Handle" is empty
-    - If an item is already claimed but its "Date Opened or Closed" cell has turned red, it is also available for you to claim (for more details see the last section of this document)
-  - Claim it by entering your slack handle along with the status "Open" and today's date, for instance: 
-  ```
-  @khdelphine Open 1/22/2017
-  ```
+- You will work on datasets that were harvested by Checkers.
+- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `BAG`, all the URLs listed are ready to be bagged
+    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
+- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- While you go through the harvesting process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
+
+**Note: the next few steps below need to be reviewed in light of the new app-driven workflow** 
 
 ## Downloading & opening the dataset
   - Go to the URL containing the zipped dataset (provided in cell "URL from upload of zip") 
@@ -82,14 +86,9 @@ Baggers do some quality assurance on the dataset to make sure the content is cor
   - Enter file size in cell "Size of bag"
 
 ## Quality assurance and finishing up
-  - To ensure that the bag was uploaded successfully, go to the URL and download the bag back to your laptop.
-  - Unzip it, open it and spot check to make sure that the bag looks well formed and the files seem valid.
-  - In the Uncrawlable spreadsheet, make sure you document all the actions you have taken by filling out all the cells.
-  - In the Uncrawlable spreadsheet, change the status to "Closed" in the cell "Current Status", for instance:
-  ```
-  @khdelphine Closed 1/22/2017
-  ```
-    - If ever a day or more passed since you originally claimed the item, update the date to today's date.
-    - Note that if more than 2 days have passed since you claimed the dataset and it is still not closed, the **Date field will turn red**, signaling that someone else can claim it in your place and start working on it
-      - This will avoid datasets being stuck in the middle of the workflow and not being finalized.
-      
+- To ensure that the bag was uploaded successfully, go to the URL and download the bag back to your laptop.
+- Unzip it, open it and spot check to make sure that the bag looks well formed and the files seem valid.
+
+- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- Check the Bag checkbox (on the right-hand side) to mark that step as completed. 
+- Click `Check in URL`, to release it and allow someone else to work on the next step. 

--- a/bagging.md
+++ b/bagging.md
@@ -25,10 +25,13 @@ The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to 
   
 ## Claiming a dataset for bagging
 - You will work on datasets that were harvested by Checkers.
-- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `BAG`, all the URLs listed are ready to be bagged
-    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
-- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `BAG`: all the URLs listed are ready to be bagged
+    - Available URLs are the ones that have not been checked out by someone else, that is, that do not have someone's name in the User column.
+- Select an available URL and click its UUID to get to the detailed view, then click `Check out this URL`. It is now ready for you to work on, and no one else can do anything to it while you have it checked out. 
 - While you go through the harvesting process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
+
+## Note: URL vs UUID
+The `URL` is the link to examine and harvest, and the `UUID` is a canonical ID we use to connect the url with the data in question. The UUID will have been generated earlier earlier in the process. UUID stands for Universal Unique Identifier. 
 
 **Note: the next few steps below need to be reviewed in light of the new app-driven workflow** 
 

--- a/checking.md
+++ b/checking.md
@@ -6,30 +6,29 @@
 Checkers inspect a harvested dataset and make sure that it is complete. The main question the checkers need to answer is "will the bag make sense to a scientist"? 
 
 ## Getting set up as a Checker
-  - Apply to become a Checker 
-    - By asking your DataRescue guide or by filling out [this form](https://docs.google.com/a/temple.edu/forms/d/e/1FAIpQLSfh9YIFnDrc-Cuc0hTd-U37J3D8xw8K7VXmzWkPs6Y5Q0wfVg/viewform) 
-    - Skills recommended: in general, Checkers need to have an in-depth understanding of harvesting goals and potential content variations for datasets.
+- Skills recommended for this role: in general, Checkers need to have an in-depth understanding of harvesting goals and potential content variations for datasets.
+- Apply to become a Checker 
+   - By asking your DataRescue guide or by filling out [this form](https://docs.google.com/a/temple.edu/forms/d/e/1FAIpQLSfh9YIFnDrc-Cuc0hTd-U37J3D8xw8K7VXmzWkPs6Y5Q0wfVg/viewform) 
     - Note that an email address is required to apply.
     - Note also that you should be willing to have your real name be associated with the datasets, to follow archival best practices (see [guidelines on archival best practices for Data Refuge](http://www.ppehlab.org/blogposts/2017/2/1/data-refuge-rests-on-a-clear-chain-of-custody) for more information).
-  - Credentials, slack invite, Uncrawlable spreadsheet URL, and other details will be provided once your application is approved.
-  - Test the Uploader application http://drp-upload.herokuapp.com with the credentials provided
-    - Make sure to select the right event in the dropdown
-  - Verify that you have write access to the Checkers tab in the Uncrawlable spreadsheet
-  - You might also need to have some other software and utilities set up on your computer, depending methods you will use, when needing to harvest supplemental materials to add to a dataset.
-  - If you need any assistance:
-      - Talk to your DataRescue Guide if you are at an in-person event
-      - Or post  questions on Slack in the #Checkers channel.
+- The organizers of the event (in-person or remote) will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
+	- Click the invite link, and choose a user name and a password.    
+- Make sure you have an account on the DataRefuge slack where people share expertise and answer each other's questions.
+	- Ask your event organizer to send you an invite 
+- You might also need to have some other software and utilities set up on your computer, depending methods you will use, when needing to harvest supplemental materials to add to a dataset.
+- If you need any assistance:
+ - Talk to your DataRescue Guide if you are at an in-person event
+ - Or post  questions on Slack in the #Checkers channel.
 
 ## Claiming a dataset for the checking step 
   - You will work on datasets that were harvested by Harvesters. 
-  - Go to the Uncrawlable spreadsheet, click the Checkers tab, and look for a dataset to check
-    - Available datasets are the ones whose cell "Checker Handle" is empty
-    - If an item is already claimed but its "Date Opened or Closed" cell has turned red, it is also available for you to claim (for more details see the last section of this document)
-  - Claim it by entering your slack handle along with the status "Open" and today's date, for instance: 
-  ```
-  @khdelphine Open 1/22/2017
-  ```
-  
+  - Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `FINALIZE`, all the URLs listed are ready to be checked
+    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
+- Click an available URL, and click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- While you go through the checking process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
+
+**Note: the next few steps below need to be reviewed in light of the new app-driven workflow ** 
+
 ## Downloading & opening the dataset
   - Go to the URL containing the zipped dataset (provided in cell "URL from upload of zip") 
   - Download the zip file to your laptop, and unzip it.
@@ -52,13 +51,13 @@ Checkers inspect a harvested dataset and make sure that it is complete. The main
   - Quality assurance: 
     - To ensure that the zip file was uploaded successfully, go to the URL and download it back to your laptop. 
     - Unzip it, open it and spot check to make sure that all the files are there and seem valid.
-  
+ 
 ## Finishing up
-  - In the Uncrawlable spreadsheet, briefly describe any change you have made in cell "Any Changes?", and answer yes or no in cell "Files in  UUID.zip are all good?" 
-  - In the Uncrawlable spreadsheet, change the status to "Closed" in the cell "Current Status", for instance: 
-  ```
-  @khdelphine Closed 1/22/2017
-  ```
-    - If ever a day or more passed  since you originally claimed the item, update the date to today's date. 
-    - Note that if more than 2 days have passed since you claimed the dataset and it is still not closed, the **Date field will turn red**, signaling that someone else can claim it in your place and start working on it
-      - This will avoid datasets being stuck in the middle of the workflow and not being finalized.
+- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- Check the Finalize checkbox (on the right-hand side) to mark that step as completed. 
+- Click `Check in URL`, to release it and allow someone else to work on the next step. 
+
+- You're done! Move on to the next URL! 
+ 
+ <!-- - In the Uncrawlable spreadsheet, briefly describe any change you have made in cell "Any Changes?", and answer yes or no in cell "Files in  UUID.zip are all good?" -->
+  

--- a/checking.md
+++ b/checking.md
@@ -8,7 +8,7 @@ Checkers inspect a harvested dataset and make sure that it is complete. The main
 ## Getting set up as a Checker
 - Skills recommended for this role: in general, Checkers need to have an in-depth understanding of harvesting goals and potential content variations for datasets.
 - Apply to become a Checker 
-   - By asking your DataRescue guide or by filling out [this form](https://docs.google.com/a/temple.edu/forms/d/e/1FAIpQLSfh9YIFnDrc-Cuc0hTd-U37J3D8xw8K7VXmzWkPs6Y5Q0wfVg/viewform) 
+   - By filling out [this form](https://docs.google.com/a/temple.edu/forms/d/e/1FAIpQLSfh9YIFnDrc-Cuc0hTd-U37J3D8xw8K7VXmzWkPs6Y5Q0wfVg/viewform) 
     - Note that an email address is required to apply.
     - Note also that you should be willing to have your real name be associated with the datasets, to follow archival best practices (see [guidelines on archival best practices for Data Refuge](http://www.ppehlab.org/blogposts/2017/2/1/data-refuge-rests-on-a-clear-chain-of-custody) for more information).
 - The organizers of the event (in-person or remote) will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.

--- a/checking.md
+++ b/checking.md
@@ -22,14 +22,13 @@ Checkers inspect a harvested dataset and make sure that it is complete. The main
 
 ## Claiming a dataset for the checking step 
   - You will work on datasets that were harvested by Harvesters. 
-  - Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `FINALIZE`, all the URLs listed are ready to be checked
-    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
-- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+  - Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `FINALIZE`: all the URLs listed are ready to be checked
+    - Available URLs are the ones that have not been checked out by someone else, that is, that do not have someone's name in the User column.
+- Select an available URL and click its UUID to get to the detailed view, then click `Check out this URL`. It is now ready for you to work on, and no one else can do anything to it while you have it checked out. 
 - While you go through the checking process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
 
 ## Note: URL vs UUID
-The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
-
+The `URL` is the link to examine and harvest, and the `UUID` is a canonical ID we use to connect the url with the data in question. The UUID will have been generated earlier earlier in the process. UUID stands for Universal Unique Identifier. 
 
 **Note: the next few steps below need to be reviewed in light of the new app-driven workflow** 
 

--- a/checking.md
+++ b/checking.md
@@ -31,7 +31,7 @@ Checkers inspect a harvested dataset and make sure that it is complete. The main
 The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
 
 
-**Note: the next few steps below need to be reviewed in light of the new app-driven workflow ** 
+**Note: the next few steps below need to be reviewed in light of the new app-driven workflow** 
 
 ## Downloading & opening the dataset
   - Go to the URL containing the zipped dataset (provided in cell "URL from upload of zip") 

--- a/checking.md
+++ b/checking.md
@@ -24,8 +24,12 @@ Checkers inspect a harvested dataset and make sure that it is complete. The main
   - You will work on datasets that were harvested by Harvesters. 
   - Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `FINALIZE`, all the URLs listed are ready to be checked
     - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
-- Click an available URL, and click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
 - While you go through the checking process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
+
+## Note: URL vs UUID
+The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
+
 
 **Note: the next few steps below need to be reviewed in light of the new app-driven workflow ** 
 

--- a/checking.md
+++ b/checking.md
@@ -57,8 +57,9 @@ The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to 
     - Unzip it, open it and spot check to make sure that all the files are there and seem valid.
  
 ## Finishing up
-- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- In the Archivers app, make sure to fill out as much information as possible to document your work.
 - Check the Finalize checkbox (on the right-hand side) to mark that step as completed. 
+- Click `Save`.
 - Click `Check in URL`, to release it and allow someone else to work on the next step. 
 
 - You're done! Move on to the next URL! 

--- a/harvesting-toolkit/README.md
+++ b/harvesting-toolkit/README.md
@@ -11,7 +11,6 @@ Harvesters take the "uncrawlable" data and try to figure out how to actually cap
   - Researchers and Harvesters should work very closely together as their work will feed from each other and much communication is needed between the two roles.
   - For instance they could work in pairs or in small groups. 
     - In some cases, a single person might be both a Researcher and a Harvester.
-  - Note that in the Uncrawlable Action spreadsheet, Researchers and Harvesters share the same tab.
   - As a Harvester, make sure to check out the [Researchers documentation](research.md) to familiarize yourself with their role.
 
 - **The notion of "meaningful dataset"**
@@ -76,7 +75,7 @@ Before starting it's best to get a directory going for the data you're going to 
 
 Each row in the above is:
 
-	A directory named by the spreadsheet ID
+	A directory named by the UUID
 		├── a .html "web archive" file of the url for future reference, named with the ID
 		├── a .json metadata file that contains relevant metadata, named with the ID
 		├── a /tools directory to include any scripts, notes & files used to acquire the data

--- a/harvesting-toolkit/README.md
+++ b/harvesting-toolkit/README.md
@@ -65,7 +65,8 @@ If the dataset you're looking at is quite large -- say, more than 1000 documents
 
 ## 3. Generate HTML, JSON & Directory
 
-Before starting it's best to get a directory going for the data you're going to archive. You will be in charge of creating and collecting this structure for each link that's deemed uncrawlable. Using the example from step 1, the structure of the archive will look like so:
+To get started click `Download Zip Starter`, which will download an empty Zip archive structure for the data you are about to harvest.
+The structure looks like this:
 
 	DAFD2E80-965F-4989-8A77-843DE716D899
 		├── DAFD2E80-965F-4989-8A77-843DE716D899.html
@@ -82,14 +83,17 @@ Each row in the above is:
 		└── a /data directory that contains the data in question
 
 
-The goal is to pass this finalized folder off for ["bagging"](example/DAFD2E80-965F-4989-8A77-843DE716D899/DAFD2E80-965F-4989-8A77-843DE716D899.json). We repeatedly use the ID so that we can programmatically work through this data later. It is important that the ID be copied *exactly*, with no leading or trailing spaces, and honoring case-sensitivity.
+### UUID 
+The goal is to pass this finalized folder off for ["bagging"](example/DAFD2E80-965F-4989-8A77-843DE716D899/DAFD2E80-965F-4989-8A77-843DE716D899.json). We repeatedly use the UUID so that we can programmatically work through this data later. It is important that the ID be copied *exactly* wherever it appears, with no leading or trailing spaces, and honoring case-sensitivity.
 
 #### [id].html file
-The first thing you'll want to create is a html copy of the page in question. The html file gives the archive a snapshot of the page at the time of archiving which we can use to monitor for changing data in the future, and corrobrate the provenance of the archive itself. We can also use the .html in conjunction with the scripts you'll include in the tools directory to replicate the archive in the future. To generate the html file, navigate to your new folder in a terminal window and run the following command:
+The zip starter archive will automatically include a copy of the page corresponding to the URL. The html file gives the archive a snapshot of the page at the time of archiving which we can use to monitor for changing data in the future, and corrobrate the provenance of the archive itself. We can also use the .html in conjunction with the scripts you'll include in the tools directory to replicate the archive in the future. 
+
+<!--To generate the html file, navigate to your new folder in a terminal window and run the following command:
 
 	wget -O DAFD2E80-965F-4989-8A77-843DE716D899.html  http://www.eia.gov/electricity/data/eia412/
 
-You'll replace ```DAFD2E80-965F-4989-8A77-843DE716D899.html``` with the ID + .html, and the url with the one you're looking at.
+You'll replace ```DAFD2E80-965F-4989-8A77-843DE716D899.html``` with the ID + .html, and the url with the one you're looking at.-->
 
 #### [id].json file
 The json file is one you'll create by hand to create a machine readable record of the archive. This file contains vital data, including the url that was archived, and date of archiving. The [id.json readme](docs/id-json.md) goes into much more detail.
@@ -155,9 +159,9 @@ It's worth using some judgement here. If a "script" you used includes an entire 
 During the process you may feel inclined to clean things up, add structure to the data, etc. Avoid temptation. Your finished archive will be hashed so we can compare it later for changes, and it's important that we archive original, unmodified content.
 
 ## 6. Uploading the data
-- Zip the all the files pertaining to your dataset, so that you have a resulting zip file.
-- Upload the Zip file by clicking `Upload` in the Archivers app, and selecting `Choose File`
-     -  Note that files beyond 5 Gigs cannot be uploaded through this method
+- Zip the all the files pertaining to your dataset within the zip started archive structure. 
+- Upload the zip file by clicking `Upload` in the Archivers app, and selecting `Choose File`
+     - Note that files beyond 5 Gigs cannot be uploaded through this method
      - Please talk to your DataRescue guide/post on Slack in Researchers/Harvesters channel, if you have a larger file
   <!--- IT WOULD BE NICE TO STILL HAVE THAT STEP: Quality assurance:
    - To ensure that the zip file was uploaded successfully, go to the URL and download it back to your computer.

--- a/harvesting-toolkit/README.md
+++ b/harvesting-toolkit/README.md
@@ -167,7 +167,7 @@ During the process you may feel inclined to clean things up, add structure to th
 ## 7. Finishing up
 - In the Archivers app, make sure to fill out as much information as possible to document your work.
 - Check the Harvest checkbox (on the right-hand side) to mark that step as completed. 
-- Click Save.
+- Click `Save`.
 - Click `Check in URL`, to release it and allow someone else to work on the next step. 
 <!-- HOW DOES THIS PROCESS WORK NOW?    - If ever a day or more passed  since you originally claimed the item, update the date to today's date. 
     - Note that if more than 2 days have passed since you claimed the dataset and it is still not closed, the **Date field will turn red**, signaling that someone else can claim it in your place and start working on it

--- a/harvesting-toolkit/README.md
+++ b/harvesting-toolkit/README.md
@@ -19,34 +19,28 @@ Harvesters take the "uncrawlable" data and try to figure out how to actually cap
   - For instance, if a dataset is composed of a spreadsheet without any accompanying key or explanation of what the data represents, it might be completely impossible for a scientist to use it.
   
 ## Getting set up as a Harvester
-  - Apply to become a Harvester 
-    - By asking your DataRescue guide or by filling out [this form](Link coming soon) 
-    - Skills recommended: in general, Harvesters need to have some tech skills and a good understanding of harvesting goals.
-    - Note that an email address is required to apply.
-  - Credentials, slack invite, Uncrawlable Action spreadsheet URL, and other details will be provided once your application is approved.
-  - Test the Uploader application http://drp-upload.herokuapp.com with the credentials provided
-    - Make sure to select the right event in the dropdown
-  - Verify that you have write access to the Researchers/Harvesters tab in the Uncrawlable Action spreadsheet
-  - You might also need to have some other software and utilities set up on your computer, depending on the harvested methods you will use.
-  - Harvesters should start by reading this document, which outlines the steps for constructing a proper data archive of the highest possible integrity. The primary focus of this document is on _semi-automated harvesting as part of a team_, and the workflow described is best-suited for volunteers working to preserve small and medium-sized collections. Where possible, we try to link out to other options appropriate to other circumstances.
+- Skills recommended for this role: in general, Harvesters need to have some tech skills and a good understanding of harvesting goals.
+- The organizers of the event (in-person or remote) will tell you how to volunteer for the Harvester role, either through slack or a form. 
+	- As a result, they will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
+	- Click the invite link, and choose a user name and a password.
+- Make sure you have an account on the DataRefuge slack where people share expertise and answer each other's questions.
+	- Ask your event organizer to send you an invite 
+- You might also need to have some other software and utilities set up on your computer, depending on the harvested methods you will use.
+- Harvesters should start by reading this document, which outlines the steps for constructing a proper data archive of the highest possible integrity. The primary focus of this document is on _semi-automated harvesting as part of a team_, and the workflow described is best-suited for volunteers working to preserve small and medium-sized collections. Where possible, we try to link out to other options appropriate to other circumstances.
   - If you need any assistance:
     - Talk to your DataRescue Guide if you are at an in-person event
     - Or post  questions on Slack in the #Researchers/Harvesters channel.
 
 ## 1. Claiming a dataset to harvest
 
- - You will work on datasets that were confirmed as unscrawlable by Researchers.
-- Go to the Uncrawlable spreadsheet, click the Researchers/Harvesters tab, and look for a dataset to harvest
-    - Available datasets are the ones (1) whose cell "Harvester handle" is empty, (2) that have been marked as crawlable=no (or yes&no) by the Researcher, and (3) have been marked as "Researcher: Current Status" = "Closed".
-    - If an item is already claimed but its "Date Opened or Closed" cell has turned red, it is also available for you to claim (for more details see the last section of this document)
-  - Claim it by entering your slack handle along with the status "Open" and today's date, for instance: 
-  ```
-  @khdelphine Open 1/22/2017
-  ```
-- Note that the Uncrawlable spreadsheet is the starting and ending point for the collective archiving efforts. Many people will be working from this shared worksheet, so it's important to report all your work in the spreadsheet and update the status cell that shows that you have claimed a URL or are done working on it.
+- You will work on datasets that were confirmed as unscrawlable by Researchers.
+- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `HARVEST`, all the URLs listed are ready to be harvested
+    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
+- Click an available URL, and click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- While you go through the harvesting process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
 
-## URL vs UUID
-The url (in cell "Original URL")  is the link to examine, the UUID (in cell "UUID") is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
+## Note: URL vs UUID
+The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
 
 ## 2a. Classify Source Type & archivability
 Before doing anything, take a minute to understand what you're looking at. It's usually best to have a quick check of the url to confirm that this data in fact not crawlable. Often as part of the harvesting team, you'll be the first person with a higher level of technical knowledge to review the url in question.
@@ -163,24 +157,20 @@ During the process you may feel inclined to clean things up, add structure to th
 
 ## 6. Uploading the data
 - Zip the all the files pertaining to your dataset, so that you have a resulting zip file.
-- Upload the Zip file using the application http://drp-upload.herokuapp.com/
-   - Make sure to select the name of your event in the dropdown (and "remote" if you are working remotely)
-   -  Note that files beyond 5 Gigs cannot be uploaded through this method
+- Upload the Zip file by clicking `Upload` in the Archivers app, and selecting `Choose File`
+     -  Note that files beyond 5 Gigs cannot be uploaded through this method
      - Please talk to your DataRescue guide/post on Slack in Researchers/Harvesters channel, if you have a larger file
-   - The application will return the url of the uploaded file. Enter it in the Uncrawlable spreadsheet in cell "URL from upload of zip" 
-- Quality assurance:
+  <!--- IT WOULD BE NICE TO STILL HAVE THAT STEP: Quality assurance:
    - To ensure that the zip file was uploaded successfully, go to the URL and download it back to your computer.
    - Unzip it, open it and spot check to make sure that all the files are there and seem valid.
-- Re-uploading: if you found a problem in your first zip (e.g., you realized you missed a file) and would like to upload an improved one, that's ok. Just proceed as you did for the first upload.
+- Re-uploading: if you found a problem in your first zip (e.g., you realized you missed a file) and would like to upload an improved one, that's ok. Just proceed as you did for the first upload.-->
 
 ## 7. Finishing up
-- In the Uncrawlable spreadsheet, fill out all cells in Harvester section to document your actions. 
-- In the Uncrawlable spreadsheet, change cell "Harvester: Current Status" to "Closed", for instance: 
-  ```
-  @khdelphine Closed 1/22/2017
-  ```
-    - If ever a day or more passed  since you originally claimed the item, update the date to today's date. 
+- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- Check the Harvest checkbox (on the right-hand side) to mark that step as completed. 
+- Click `Check in URL`, to release it and allow someone else to work on the next step. 
+<!-- HOW DOES THIS PROCESS WORK NOW?    - If ever a day or more passed  since you originally claimed the item, update the date to today's date. 
     - Note that if more than 2 days have passed since you claimed the dataset and it is still not closed, the **Date field will turn red**, signaling that someone else can claim it in your place and start working on it
-      - This will avoid datasets being stuck in the middle of the workflow and not being finalized.
+      - This will avoid datasets being stuck in the middle of the workflow and not being finalized.-->
 
 - You're done! Move on to the next URL!

--- a/harvesting-toolkit/README.md
+++ b/harvesting-toolkit/README.md
@@ -31,15 +31,14 @@ Harvesters take the "uncrawlable" data and try to figure out how to actually cap
     - Or post  questions on Slack in the #Researchers/Harvesters channel.
 
 ## 1. Claiming a dataset to harvest
-
 - You will work on datasets that were confirmed as unscrawlable by Researchers.
-- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `HARVEST`, all the URLs listed are ready to be harvested
-    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
-- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `HARVEST`: all the URLs listed are ready to be harvested
+   - Available URLs are the ones that have not been checked out by someone else, that is, that do not have someone's name in the User column.
+- Select an available URL and click its UUID to get to the detailed view, then click `Check out this URL`. It is now ready for you to work on, and no one else can do anything to it while you have it checked out. 
 - While you go through the harvesting process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
 
 ## Note: URL vs UUID
-The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
+The `URL` is the link to examine and harvest, and the `UUID` is a canonical ID we use to connect the url with the data in question. The UUID will have been generated earlier earlier in the process. UUID stands for Universal Unique Identifier. 
 
 ## 2a. Classify Source Type & archivability
 Before doing anything, take a minute to understand what you're looking at. It's usually best to have a quick check of the url to confirm that this data in fact not crawlable. Often as part of the harvesting team, you'll be the first person with a higher level of technical knowledge to review the url in question.

--- a/harvesting-toolkit/README.md
+++ b/harvesting-toolkit/README.md
@@ -35,7 +35,7 @@ Harvesters take the "uncrawlable" data and try to figure out how to actually cap
 - You will work on datasets that were confirmed as unscrawlable by Researchers.
 - Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `HARVEST`, all the URLs listed are ready to be harvested
     - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
-- Click an available URL, and click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
 - While you go through the harvesting process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
 
 ## Note: URL vs UUID

--- a/harvesting-toolkit/README.md
+++ b/harvesting-toolkit/README.md
@@ -165,8 +165,9 @@ During the process you may feel inclined to clean things up, add structure to th
 - Re-uploading: if you found a problem in your first zip (e.g., you realized you missed a file) and would like to upload an improved one, that's ok. Just proceed as you did for the first upload.-->
 
 ## 7. Finishing up
-- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- In the Archivers app, make sure to fill out as much information as possible to document your work.
 - Check the Harvest checkbox (on the right-hand side) to mark that step as completed. 
+- Click Save.
 - Click `Check in URL`, to release it and allow someone else to work on the next step. 
 <!-- HOW DOES THIS PROCESS WORK NOW?    - If ever a day or more passed  since you originally claimed the item, update the date to today's date. 
     - Note that if more than 2 days have passed since you claimed the dataset and it is still not closed, the **Date field will turn red**, signaling that someone else can claim it in your place and start working on it

--- a/research.md
+++ b/research.md
@@ -24,7 +24,7 @@ Researchers inspect the "uncrawlable" list to confirm that seeders' assessments 
 - Researchers work on datasets that were listed as uncrawlable by Seeders.
 - Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `RESEARCH`, all the URLs listed are ready to be researched
     - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
-- Click an available URL, and click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
 - While you go through the research process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
 
 ## Note: URL vs UUID

--- a/research.md
+++ b/research.md
@@ -4,15 +4,15 @@
 Researchers inspect the "uncrawlable" list to confirm that seeders' assessments were correct (that is, that the URL/dataset is indeed uncrawlable), and investigate how the dataset could be best harvested.
 
 ## Getting set up as a Researcher
- - Apply to become a Researcher 
-    - By asking your DataRescue guide or by filling out [this form](Link coming soon) 
-    - Skills recommended: in general, Researchers need to have a good understanding of harvesting goals and have some familiarity with datasets. Ideally they would understand how federal data is organized (e.g. where the "master" datasets are vs. the derived partial views of those datasets.
-    - Note that an email address is required to apply.
-  - Uncrawlable spreadsheet URL, slack invite, and other details will be provided once your application is approved.
-  - Verify that you have write access to the Researchers/Harvesters tab in the Uncrawlable spreadsheet
-  - If you need any assistance:
-    - Talk to your DataRescue Guide if you are at an in-person event
-    - Or post questions on Slack in the #Researchers/Harvesters channel.
+ - Skills recommended for this role: in general, Researchers need to have a good understanding of harvesting goals and have some familiarity with datasets. Ideally they would understand how federal data is organized (e.g. where the "master" datasets are vs. the derived partial views of those datasets.
+- The organizers of the event (in-person or remote) will tell you how to volunteer for the Researcher role, either through slack or a form. 
+	- As a result, they will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
+	- Click the invite link, and choose a user name and a password.
+- Make sure you have an account on the DataRefuge slack where people share expertise and answer each other's questions.
+	- Ask your event organizer to send you an invite  
+- If you need any assistance:
+ - Talk to your DataRescue Guide if you are at an in-person event
+ - Or post questions on Slack in the #Researchers/Harvesters channel.
     
 ## Researchers and Harvesters
 - Researchers and Harvesters should work very closely together as their work will feed from each other and much communication is needed between the two roles.
@@ -21,17 +21,15 @@ Researchers inspect the "uncrawlable" list to confirm that seeders' assessments 
 - Note that in the Uncrawlable Action spreadsheet, Researchers and Harvesters share the same tab.
 - As a Researcher, make sure to check out the [Harvesters documentation](harvesting-toolkit) to familiarize yourself with their role.
 
-## Claiming a dataset to harvest
-
+## Claiming a dataset to Research
 - Researchers work on datasets that were listed as uncrawlable by Seeders.
-- Go to the Uncrawlable spreadsheet, click the Researchers/Harvesters tab, and look for a dataset to harvest
-  - Available datasets are the ones whose cell "Researcher Handle" is empty
-  - If an item is already claimed but its "Date Opened or Closed" cell has turned red, it is also available for you to claim (for more details see the last section of this document)
-    - Claim it by entering your slack handle along with the status "Open" and today's date, for instance: 
-    ```
-    @khdelphine Open 1/22/2017
-    ```
-- You will find the URL you are about to evaluate in the "Original URL" cell.
+- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `RESEARCH`, all the URLs listed are ready to be researched
+    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
+- Click an available URL, and click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- While you go through the research process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
+
+## Note: URL vs UUID
+The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
 
 ## Evaluating the data
 Go to the URL, and start inspecting the content.
@@ -61,28 +59,27 @@ What to do in each case:
     [Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok),
     and if that doesn't work then use the
     [bookmarklet](http://digital2.library.unt.edu/nomination/eth2016/about/)
-  - Fill out the cell "Can it be crawled?" = "yes" in Uncrawlable spreadsheet
-  - Fill out cell "Seeded?" = "yes" and tell what URL you seeded. 
+  - Click checkbox `Do not harvest` in Archivers app.
+ <!-- why don't we ask that any more?  - Fill out cell "Seeded?" = "yes" and tell what URL you seeded. -->
  - **NO**: If it is confirmed not crawlable:
-   - Fill out the cell "Can it be crawled?" = "no" in  Researcher section of the spreadsheet
+  <!-- Why don't we ask that any more? - Fill out the cell "Can it be crawled?" = "no" in  Researcher section of the spreadsheet-->
   - Search agency websites and data.gov for dataset entry points for your dataset collection   
       - Tips: Try to understand what data sets are underlying the web pages. Look for related entries in the spreadsheet, and ensure that you aren't harvesting a subdirectory if you can harvest the entire directory. Often, data underlying dozens of pages or multiple "access portal" apps is also available as one structured data file.
-  - Add your suggested url for harvesting the data to spreadsheet (in cell "Harvestable Data"), REALLY IMPORTANT!
-  -  Also add other information in the spreadsheet that could help the Harvester, such as information about format (SQL, FTP, ZIP, PDF Collections, etc.), size, details about what you found, recommended approach, etc. 
-  - Search for related URLS in the spreadsheet that might be covered by the same approach so as not to duplicate work (in cell "URL duplicate UUID").
+ <!-- - Add your suggested url for harvesting the data to spreadsheet (in cell "Harvestable Data"), REALLY IMPORTANT!-->
+  - Also add other information in the spreadsheet that could help the Harvester, such as information about format (SQL, FTP, ZIP, PDF Collections, etc.), size, details about what you found, recommended approach, etc. 
+  - Search for related URLS in the spreadsheet that might be covered by the same approach so as not to duplicate work (in `Link URL` field in Archivers app).
 - **YES AND NO**: for example, FTP address, mixed content, big data sets:
-   - Fill out the cell "Can it be crawled?" = "yes & no" in Researcher section of the spreadsheet
-  - Nominate it anyway, but follow the steps for uncrawlable content above.
-  - *While we understand that this may result in some dataset duplication, that is not a concern. We are ensuring that the data is fully preserved and accessible.*
+ <!--  - Fill out the cell "Can it be crawled?" = "yes & no" in Researcher section of the spreadsheet-->
+  - Nominate it anyway, but also follow the steps for uncrawlable content above.
+  - *While we understand that this may result in some dataset duplication, that is not a concern. We are ensuring that the data is fully preserved and accessible.* 
 
 
 ## Finishing up
-- In the Uncrawlable spreadsheet, change the status to "Closed" in the cell "Researcher: Current Status", for instance: 
-  ```
-  @khdelphine Closed 1/22/2017
-  ```
-    - If ever a day or more passed since you originally claimed the item, update the date to today's date. 
+- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- Check the Research checkbox (on the right-hand side) to mark that step as completed. 
+- Click `Check in URL`, to release it and allow someone else to work on the next step. 
+<!-- HOW DOES THIS PROCESS WORK NOW:    - If ever a day or more passed  since you originally claimed the item, update the date to today's date. 
     - Note that if more than 2 days have passed since you claimed the dataset and it is still not closed, the **Date field will turn red**, signaling that someone else can claim it in your place and start working on it
-      - This will avoid datasets being stuck in the middle of the workflow and not being finalized.
-      
+      - This will avoid datasets being stuck in the middle of the workflow and not being finalized.-->
+            
 - You're done! Move on to the next URL!

--- a/research.md
+++ b/research.md
@@ -22,13 +22,13 @@ Researchers inspect the "uncrawlable" list to confirm that seeders' assessments 
 
 ## Claiming a dataset to Research
 - Researchers work on datasets that were listed as uncrawlable by Seeders.
-- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `RESEARCH`, all the URLs listed are ready to be researched
-    - Available URLs are the ones that have not been checked out by someone else, that is, do not have someone's name in the User column.
-- Select an available URL and click its UUID, then click `Check out this URL`. It is now ready for you to work on, no one else can do anything to it while you have it checked out. 
+- Go to the [Archivers app](http://www.archivers.space/), click `URLS` and then `RESEARCH`: all the URLs listed are ready to be researched
+    - Available URLs are the ones that have not been checked out by someone else, that is, that do not have someone's name in the User column.
+- Select an available URL and click its UUID to get to the detailed view, then click `Check out this URL`. It is now ready for you to work on, and no one else can do anything to it while you have it checked out. 
 - While you go through the research process, make sure to report as much information as possible in the Archivers app, as this is the place were we collectively keep track of all the work done.
 
 ## Note: URL vs UUID
-The `URL` is the link to examine, and the `UUID` is a canonical ID we'll use to connect the url with the data in question. The UUID will have been generated already by the DataRefuge organizers. UUID stands for Universal Unique Identifier. 
+The `URL` is the link to examine and harvest, and the `UUID` is a canonical ID we use to connect the url with the data in question. The UUID will have been generated earlier earlier in the process. UUID stands for Universal Unique Identifier. 
 
 ## Evaluating the data
 Go to the URL, and start inspecting the content.

--- a/research.md
+++ b/research.md
@@ -63,10 +63,11 @@ What to do in each case:
  - **NO**: If it is confirmed not crawlable:
   <!-- Why don't we ask that any more? - Fill out the cell "Can it be crawled?" = "no" in  Researcher section of the spreadsheet-->
   - Search agency websites and data.gov for dataset entry points for your dataset collection   
-      - Tips: Try to understand what data sets are underlying the web pages. Look for related entries in the Archivers app, and ensure that you aren't harvesting a subdirectory if you can harvest the entire directory. Often, data underlying dozens of pages or multiple "access portal" apps is also available as one structured data file.
+      - Tips: Try to understand what data sets are underlying the web pages. Look for related entries in the Archivers app, and ensure that you aren't harvesting a subdirectory if you can harvest the entire directory. Often, data underlying dozens of pages or multiple "access portal" apps is also available as one structured data file. 
+      - Make note of any better entry point in the `Recommended Approach`field, along with any other recommendations on how to proceed with this harvest.
  <!-- - Add your suggested url for harvesting the data to spreadsheet (in cell "Harvestable Data"), REALLY IMPORTANT!-->
-  - Also add other information in the Archivers app that could help the Harvester, such as information about format (SQL, FTP, ZIP, PDF Collections, etc.), size, details about what you found, recommended approach, etc. 
-  - Search for related URLS in the Archivers app that might be covered by the same approach so as not to duplicate work, and list them in `Link URL` field.
+  - Add other information that could help the Harvester, such as the format (SQL, FTP, ZIP, PDF Collections, etc.), approximate size, details about what you found, etc. 
+  - Search for related URLS that might already have been listed in the Archivers app that might be covered by the same approach, so as not to duplicate work. You can search for them in the `Link URL` field.
 - **YES AND NO**: for example, FTP address, mixed content, big data sets:
  <!--  - Fill out the cell "Can it be crawled?" = "yes & no" in Researcher section of the spreadsheet-->
   - Nominate it anyway, but also follow the steps for uncrawlable content above.

--- a/research.md
+++ b/research.md
@@ -74,8 +74,9 @@ What to do in each case:
 
 
 ## Finishing up
-- In the Archivers app, make sure to fill out as much information as possible to document your work and click `Save`
+- In the Archivers app, make sure to fill out as much information as possible to document your work.
 - Check the Research checkbox (on the right-hand side) to mark that step as completed. 
+- Click `Save`.
 - Click `Check in URL`, to release it and allow someone else to work on the next step. 
 <!-- HOW DOES THIS PROCESS WORK NOW:    - If ever a day or more passed  since you originally claimed the item, update the date to today's date. 
     - Note that if more than 2 days have passed since you claimed the dataset and it is still not closed, the **Date field will turn red**, signaling that someone else can claim it in your place and start working on it

--- a/research.md
+++ b/research.md
@@ -4,12 +4,12 @@
 Researchers inspect the "uncrawlable" list to confirm that seeders' assessments were correct (that is, that the URL/dataset is indeed uncrawlable), and investigate how the dataset could be best harvested.
 
 ## Getting set up as a Researcher
- - Skills recommended for this role: in general, Researchers need to have a good understanding of harvesting goals and have some familiarity with datasets. Ideally they would understand how federal data is organized (e.g. where the "master" datasets are vs. the derived partial views of those datasets.
+- Skills recommended for this role: in general, Researchers need to have a good understanding of harvesting goals and have some familiarity with datasets. Ideally they would understand how federal data is organized (e.g. where the "master" datasets are vs. the derived partial views of those datasets.
 - The organizers of the event (in-person or remote) will tell you how to volunteer for the Researcher role, either through slack or a form. 
-	- As a result, they will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
-	- Click the invite link, and choose a user name and a password.
+  - As a result, they will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
+  - Click the invite link, and choose a user name and a password.
 - Make sure you have an account on the DataRefuge slack where people share expertise and answer each other's questions.
-	- Ask your event organizer to send you an invite  
+  - Ask your event organizer to send you an invite  
 - If you need any assistance:
  - Talk to your DataRescue Guide if you are at an in-person event
  - Or post questions on Slack in the #Researchers/Harvesters channel.
@@ -18,7 +18,6 @@ Researchers inspect the "uncrawlable" list to confirm that seeders' assessments 
 - Researchers and Harvesters should work very closely together as their work will feed from each other and much communication is needed between the two roles.
 - For instance they could work in pairs or in small groups. 
   - In some cases, a single person might be both a Researcher and a Harvester.
-- Note that in the Uncrawlable Action spreadsheet, Researchers and Harvesters share the same tab.
 - As a Researcher, make sure to check out the [Harvesters documentation](harvesting-toolkit) to familiarize yourself with their role.
 
 ## Claiming a dataset to Research
@@ -64,10 +63,10 @@ What to do in each case:
  - **NO**: If it is confirmed not crawlable:
   <!-- Why don't we ask that any more? - Fill out the cell "Can it be crawled?" = "no" in  Researcher section of the spreadsheet-->
   - Search agency websites and data.gov for dataset entry points for your dataset collection   
-      - Tips: Try to understand what data sets are underlying the web pages. Look for related entries in the spreadsheet, and ensure that you aren't harvesting a subdirectory if you can harvest the entire directory. Often, data underlying dozens of pages or multiple "access portal" apps is also available as one structured data file.
+      - Tips: Try to understand what data sets are underlying the web pages. Look for related entries in the Archivers app, and ensure that you aren't harvesting a subdirectory if you can harvest the entire directory. Often, data underlying dozens of pages or multiple "access portal" apps is also available as one structured data file.
  <!-- - Add your suggested url for harvesting the data to spreadsheet (in cell "Harvestable Data"), REALLY IMPORTANT!-->
-  - Also add other information in the spreadsheet that could help the Harvester, such as information about format (SQL, FTP, ZIP, PDF Collections, etc.), size, details about what you found, recommended approach, etc. 
-  - Search for related URLS in the spreadsheet that might be covered by the same approach so as not to duplicate work (in `Link URL` field in Archivers app).
+  - Also add other information in the Archivers app that could help the Harvester, such as information about format (SQL, FTP, ZIP, PDF Collections, etc.), size, details about what you found, recommended approach, etc. 
+  - Search for related URLS in the Archivers app that might be covered by the same approach so as not to duplicate work, and list them in `Link URL` field.
 - **YES AND NO**: for example, FTP address, mixed content, big data sets:
  <!--  - Fill out the cell "Can it be crawled?" = "yes & no" in Researcher section of the spreadsheet-->
   - Nominate it anyway, but also follow the steps for uncrawlable content above.


### PR DESCRIPTION
This is a first effort to adapt the documentation to the app-driven workflow. Note that there is still quite a bit to do, especially to make the Checkers and Baggers sections coherent. Also Describers is marked as being inactive for now, as the role is being redeveloped.