### PR TITLE
Add gitignore remove jekyll config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+site/
+env/
+dist/
+htmlcov/
+.tox/
+mkdocs.egg-info/
+*.pyc
+.coverage

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
The .gitignore will prevent files created from `mkdocs gh-deploy` from accidentally being committed to the repo