### PR TITLE
Remove checkers from toc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ $ mkdocs serve
 
 Once a pull request has been merged into master, the gh-pages need to be regenerated. To do that, go to your local master branch at the command line and run: 
 ```
-mkdocs gh-deploy
+$ mkdocs gh-deploy
 ```
 
 _These guidelines are based on [Toronto Mesh](https://github.com/tomeshnet) and [EDGI's](https://github.com/edgi-govdata-archiving)._

--- a/docs/checking.md
+++ b/docs/checking.md
@@ -1,3 +1,5 @@
+**This document is currently unused, as the Archivers app does not have a separate Checking phase at this time. Instead we have added Checking instructions in the Bagging documentation.
+
 ## What Do Checkers Do?
 
 Checkers inspect a harvested dataset and make sure that it is complete. The main question Checkers need to answer is "will the bag make sense to a scientist"?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -89,7 +89,7 @@ Please read the DataRescue Workflow documentation for more info!
 
 ## 15) I have a process improvement that would make this go better!
 
-Great! Open an issue in your event's GitHub reposiory, or report it in the appropriate channel in your Slack team.
+Great! Open an issue in your event's GitHub repository, or report it in the appropriate channel in your Slack team.
 
 
 ## 16) How do I add a new event?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,11 +3,10 @@ pages:
     - Home: index.md
     - Advance Work: advance-work.md
     - Seeding: seeding.md
-    - Researching: research.md
+    - Researching: researching.md
     - Harvesting: harvesting.md
-    - Checking: checking.md
     - Bagging: bagging.md
-    - Describing: metadata.md
+    - Describing: describing.md
     - Archivers App FAQ: faq.md
 theme: readthedocs
 theme_dir: custom_theme


### PR DESCRIPTION
We should not have the Checking document appear in the guide at this time, since there is no separate Checkers phase in the app. Instead we have added Checking instructions in Bagging.

Also fixed a few small issues.