### PR TITLE
Add Team to Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Our process for accepting changes has a few steps.
 
         https://github.com/datarefuge/workflow/pull/new/master
 
-4. Once your changes are ready for final review, commit your changes then modify or **create your pull request (PR)**, assign a reviewer or ping those able to review (using "`@datarefuge/workflow`") and merge in PRs: @khdelphine, @dcwalk, @liblaurie or @titaniumbones.
+4. Once your changes are ready for final review, commit your changes then modify or **create your pull request (PR)**, assign a reviewer or ping (using "`@datarefuge/workflow`") those able to review and merge in PRs: @khdelphine, @dcwalk, @liblaurie or @titaniumbones.
 
 5. Allow others sufficient **time for review and comments** before merging. We make use of GitHub's review feature to to comment in-line one PRs when possible. There may be some fixes or adjustments you'll have to make based on feedback.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-We love improvements to our documentation! 
+We love improvements to our documentation!
 
 ## Submitting an issue
 
@@ -26,20 +26,20 @@ Our process for accepting changes has a few steps.
 
         https://github.com/datarefuge/workflow/pull/new/master
 
-4. Once your changes are ready for final review, commit your changes then modify or **create your pull request (PR)**, assign as a reviewer or ping (using "`@<username>`"). For instance: @khdelphine, @dcwalk, @liblaurie or @titaniumbones.
+4. Once your changes are ready for final review, commit your changes then modify or **create your pull request (PR)**, assign a reviewer or ping those able to review (using "`@datarefuge/workflow`") and merge in PRs: @khdelphine, @dcwalk, @liblaurie or @titaniumbones.
 
 5. Allow others sufficient **time for review and comments** before merging. We make use of GitHub's review feature to to comment in-line one PRs when possible. There may be some fixes or adjustments you'll have to make based on feedback.
 
 6. Once you have integrated comments, or waited for feedback, your changes should get merged in!
 
 ## Incremental changes
-Note that it is better to submit incremental bite-size changes that are easier to review. 
+Note that it is better to submit incremental bite-size changes that are easier to review.
 
 If you have in mind heavy changes, especially if they will affect the overall structure of the documentation, please discuss your plans with the other editors first.
 
 ## Viewing the final formatting as you edit
 
-Documentation is built with [MkDocs](http://www.mkdocs.org/), a static site generator tailored to writing documentation. 
+Documentation is built with [MkDocs](http://www.mkdocs.org/), a static site generator tailored to writing documentation.
 
 [Install Mkdocs](http://www.mkdocs.org/#installation) with a package manager or python/pip:
 
@@ -51,7 +51,7 @@ or
 $ pip install mkdocs
 ```
 
-Clone this repo and navigate to it, make changes to the `.md` files. 
+Clone this repo and navigate to it, make changes to the `.md` files.
 
 You can view changes via your browser at `http://127.0.0.1:8000`, by running the command:
 
@@ -61,7 +61,7 @@ $ mkdocs serve
 
 **Note that Mkdocs enforces the Markdown syntax strictly, please refer to [this Markdown guide](https://guides.github.com/features/mastering-markdown/), as well as [this one](http://www.mkdocs.org/user-guide/writing-your-docs/#markdown-extensions) for details.**
 
-Once a pull request has been merged into master, the gh-pages need to be regenerated. To do that, go to your local master branch at the command line and run: 
+Once a pull request has been merged into master, the gh-pages need to be regenerated. To do that, go to your local master branch at the command line and run:
 ```
 $ mkdocs gh-deploy
 ```


### PR DESCRIPTION
This closes #74 remaining todos, and makes clear the @datarefuge/workflow team can be pinged for review