### PR TITLE
Add extra docs to menu and inline

### DIFF
--- a/custom_theme/toc.html
+++ b/custom_theme/toc.html
@@ -1,0 +1,30 @@
+{% if nav_item.children %}
+    <ul class="subnav">
+    <li><span>{{ nav_item.title }}</span></li>
+
+        {% for nav_item in nav_item.children %}
+            {% include 'toc.html' %}
+        {% endfor %}
+
+        <li class="toctree-l1">
+            <a class="{% if nav_item.active%}current{%endif%}" href="https://youtu.be/tvSSILnHnpA" target="_blank">Archivers App Walkthrough</a>
+        </li>
+        <li class="toctree-l1">
+            <a class="{% if nav_item.active%}current{%endif%}" href="https://drive.google.com/file/d/0B8Gv3Zy5ceY3X0xiSlV2dnhMYWc/view" target="_blank">Crawlable or Uncrawlable Poster</a>
+        </li>
+    </ul>
+{% else %}
+    <li class="toctree-l1 {% if nav_item.active%}current{%endif%}">
+        <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+        {% if nav_item == page %}
+            <ul>
+            {% for toc_item in page.toc %}
+                <li class="toctree-l3"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+                {% for toc_item in toc_item.children %}
+                    <li><a class="toctree-l4" href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+                {% endfor %}
+            {% endfor %}
+            </ul>
+        {% endif %}
+    </li>
+{% endif %}

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -33,7 +33,7 @@ Harvesters take the "uncrawlable" data and try to figure out how to actually cap
 
 <div class = "note">
   <strong>Using Archivers App</strong> <br />  
-  Review our Walkthrough and refer to the <a href="/faq/">FAQ</a> for any additional questions on using the [Archivers app](http://www.archivers.space/). <br />
+  Review our walkthrough video below and refer to the <a href="/faq/">FAQ</a> for any additional questions about the <a href="http://www.archivers.space" target="_blank">Archivers app</a><!---_--->. <br />
   &nbsp;<br />
   <p style="text-align:center"><iframe width="520" height="315" src="https://www.youtube.com/embed/tvSSILnHnpA" frameborder="0" allowfullscreen></iframe></p>
 </div>

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -24,12 +24,19 @@ Harvesters take the "uncrawlable" data and try to figure out how to actually cap
 - The organizers of the event (in-person or remote) will tell you how to volunteer for the Harvester role, either through Slack or a form.
     - They will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
     - Click the invite link, and choose a username and a password. It is helpful to use the same username on the app and Slack.
-- Create an account on the DataRefuge Slack using this [slack-in](https://rauchg-slackin-qonsfhhvxs.now.sh/) (or use the Slack team recommended by your event organizers). This is where people share expertise and answer each other's questions. 
+- Create an account on the DataRefuge Slack using this [slack-in](https://rauchg-slackin-qonsfhhvxs.now.sh/) (or use the Slack team recommended by your event organizers). This is where people share expertise and answer each other's questions.
 - You might also need other software and utilities set up on your computer, depending on the harvesting methods you use.
 - Harvesters should start by reading this document, which outlines the steps for constructing a proper data archive of the highest possible integrity. The primary focus of this document is on _semi-automated harvesting as part of a team_, and the workflow described is best-suited for volunteers working to preserve small and medium-sized collections. Where possible, we try to link out to other options appropriate to other circumstances.
     - If you need any assistance:
         - Talk to your DataRescue guide if you are at an in-person event
         - Or post questions on Slack in the #Researchers/Harvesters channel (or other channel recommended by your event organizers).
+
+<div class = "note">
+  <strong>Using Archivers App</strong> <br />  
+  Review our Walkthrough and refer to the <a href="/faq/">FAQ</a> for any additional questions on using the [Archivers app](http://www.archivers.space/). <br />
+  &nbsp;<br />
+  <p style="text-align:center"><iframe width="520" height="315" src="https://www.youtube.com/embed/tvSSILnHnpA" frameborder="0" allowfullscreen></iframe></p>
+</div>
 
 ## Harvesting Toolkit
 

--- a/docs/researching.md
+++ b/docs/researching.md
@@ -19,7 +19,7 @@ Researchers review "uncrawlables" identified during [Seeding](seeding.md), confi
 
 <div class = "note">
   <strong>Using Archivers App</strong> <br />  
-  Review our Walkthrough and refer to the <a href="/faq/">FAQ</a> for any additional questions on using the [Archivers app](http://www.archivers.space/). <br />
+  Review our walkthrough video below and refer to the <a href="/faq/">FAQ</a> for any additional questions about the <a href="http://www.archivers.space" target="_blank">Archivers app</a><!---_--->. <br />
   &nbsp;<br />
   <p style="text-align:center"><iframe width="520" height="315" src="https://www.youtube.com/embed/tvSSILnHnpA" frameborder="0" allowfullscreen></iframe></p>
 </div>

--- a/docs/researching.md
+++ b/docs/researching.md
@@ -12,10 +12,17 @@ Researchers review "uncrawlables" identified during [Seeding](seeding.md), confi
 - Event organizers (in-person or remote) will tell you how to volunteer for the Researcher role, either through Slack or a form.
     - They will send you an invite to the [Archivers app](http://www.archivers.space/), which helps us coordinate all the data archiving work we do.
     - Click the invite link, and choose a username and a password. It is helpful to use the same username on the app and Slack.
-- Create an account on the DataRefuge Slack using this [slack-in](https://rauchg-slackin-qonsfhhvxs.now.sh/) or use the Slack team recommended by your event organizers. This is where people share expertise and answer each other's questions. 
+- Create an account on the DataRefuge Slack using this [slack-in](https://rauchg-slackin-qonsfhhvxs.now.sh/) or use the Slack team recommended by your event organizers. This is where people share expertise and answer each other's questions.
 - If you need any assistance:
     - Talk to your DataRescue guide if you are at an in-person event
     - Or post questions on Slack in the `#general` channel (or other channel recommended by your event organizers).
+
+<div class = "note">
+  <strong>Using Archivers App</strong> <br />  
+  Review our Walkthrough and refer to the <a href="/faq/">FAQ</a> for any additional questions on using the [Archivers app](http://www.archivers.space/). <br />
+  &nbsp;<br />
+  <p style="text-align:center"><iframe width="520" height="315" src="https://www.youtube.com/embed/tvSSILnHnpA" frameborder="0" allowfullscreen></iframe></p>
+</div>
 
 ## Researchers and Harvesters
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ pages:
     - Harvesting: harvesting.md
     - Checking/Bagging: bagging.md
     - Describing: describing.md
-    - Archivers App FAQ: faq.md
+    - Additional Resources:
+      - Archivers App FAQ: faq.md
 theme: readthedocs
 theme_dir: custom_theme


### PR DESCRIPTION
Hey @khdelphine how does this look in terms of integrating the docs?

- Added them to menu as direct links (open in a new window), introducing hierarchy as before
- Added a note to reference them on the researchers and harvesters page