### PR TITLE
Issue #93: change references to EOT Harvester in the seeder documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ This document describes DataRescue activities both at in-person events and remot
 
 ### 1. [Seeding](seeding.md)
 
-Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the Internet Archive's webcrawler. If the URLs are crawlable, the Seeders save them to the Internet Archive. Otherwise, they add them to the Archivers app using [the project's Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
+Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the [Internet Archive's](http://archive.org) webcrawler. If the URLs are crawlable, the Seeders save them to the Internet Archive. Otherwise, they add them to the Archivers app using [the project's Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
 
 ### 2. [Researching](researching.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ This document describes DataRescue activities both at in-person events and remot
 
 ### 1. [Seeding](seeding.md)
 
-Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the [Internet Archive's](http://archive.org) webcrawler. If the URLs are crawlable, the Seeders save them to the Internet Archive. Otherwise, they add them to the Archivers app using [the project's Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
+Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the [Internet Archive's](http://archive.org) webcrawler. If the URLs are crawlable, the Seeders nominate them to the Internet Archive. Otherwise, they add them to the Archivers app using [the project's Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
 
 ### 2. [Researching](researching.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ This document describes DataRescue activities both at in-person events and remot
 
 ### 1. [Seeding](seeding.md)
 
-Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the Internet Archive's webcrawler. If the URLs are crawlable, the Seeders nominate them to the Internet Archive. Otherwise, they add them to the Archivers app using the project's Chrome Extension.
+Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the Internet Archive's webcrawler. If the URLs are crawlable, the Seeders save them to the Internet Archive. Otherwise, they add them to the Archivers app using [the project's Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
 
 ### 2. [Researching](researching.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ This document describes DataRescue activities both at in-person events and remot
 
 ### 1. [Seeding](seeding.md)
 
-Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the Internet Archive's webcrawler. If the URLs are crawlable, the Seeders nominate them to the End-of-Term (EOT) project. Otherwise, they add them to the Archivers app using the project's Chrome Extension.
+Seeders canvass the resources of a given government agency, identifying important URLs. They identify whether those URLs can be crawled by the Internet Archive's webcrawler. If the URLs are crawlable, the Seeders nominate them to the Internet Archive. Otherwise, they add them to the Archivers app using the project's Chrome Extension.
 
 ### 2. [Researching](researching.md)
 

--- a/docs/seeding.md
+++ b/docs/seeding.md
@@ -21,7 +21,7 @@ Seeders use the [EDGI Archiving Primers](https://envirodatagov.org/archiving/), 
 
 ### Crawlable URLs
 
-- URLs judged to be crawlable are saved ("seeded") to the Internet Archive, using the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
+- URLs judged to be crawlable are nominated ("seeded") to the Internet Archive, using the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
 
 **Wherever possible, add in the Agency Office Code from the sub-primer.** Talk to the DataRescue organizers to learn more.
 

--- a/docs/seeding.md
+++ b/docs/seeding.md
@@ -21,7 +21,7 @@ Seeders use the [EDGI Archiving Primers](https://envirodatagov.org/archiving/), 
 
 ### Crawlable URLs
 
-- URLs judged to be crawlable are "nominated" (equivalently, "seeded") to the Internet Archive, using the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
+- URLs judged to be crawlable are saved ("seeded") to the Internet Archive, using the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
 
 **Wherever possible, add in the Agency Office Code from the sub-primer.** Talk to the DataRescue organizers to learn more.
 

--- a/docs/seeding.md
+++ b/docs/seeding.md
@@ -1,6 +1,6 @@
 ## What Do Seeders Do?
 
-Seeders canvass the resources of a given government agency, identifying important URLs and whether those URLs can be crawled by the Internet Archive's web crawler. They use the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en) to nominate URLs to the [End of Term (EOT) Web Archive](http://eotarchive.cdlib.org/2016.html) if they are crawlable or to the Archivers app if they require manual archiving.
+Seeders canvass the resources of a given government agency, identifying important URLs and whether those URLs can be crawled by the Internet Archive's web crawler. They use the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en) to nominate URLs to the [Internet Archive](http://www.archive.org) if they are crawlable or to the Archivers app if they require manual archiving.
 
 <div class = "note">
   <strong>Recommended Skills</strong> <br />  
@@ -21,7 +21,7 @@ Seeders use the [EDGI Archiving Primers](https://envirodatagov.org/archiving/), 
 
 ### Crawlable URLs
 
-- URLs judged to be crawlable are "nominated" (equivalently, "seeded") to the End of Term project (EOT), using the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
+- URLs judged to be crawlable are "nominated" (equivalently, "seeded") to the Internet Archive, using the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
 
 **Wherever possible, add in the Agency Office Code from the sub-primer.** Talk to the DataRescue organizers to learn more.
 


### PR DESCRIPTION
Changed references to End of Term to Internet Archive and updated URL.