### PR TITLE
Add instructions for Chrome Nomination tool 

### DIFF
--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -36,7 +36,7 @@ For in-depth information on tools and techniques to harvest open data, please ch
 
 <div class = "note">
   <strong>Using Archivers App</strong> <br />  
-  Review our walkthrough video below and refer to the <a href="/faq/">FAQ</a> for any additional questions about the <a href="http://www.archivers.space" target="_blank">Archivers app</a><!---_--->. <br />
+  Review our walkthrough video below and refer to the <a href="/faq/">FAQ</a> for any additional questions about the <a href="http://www.archivers.space" target="_blank">Archivers app</a><!--_-->. <br />
   &nbsp;<br />
   <p style="text-align:center"><iframe width="80%" height="315" src="https://www.youtube.com/embed/tvSSILnHnpA" frameborder="0" allowfullscreen></iframe></p>
 </div>
@@ -67,6 +67,8 @@ Before doing anything, take a minute to understand what you're looking at. It's 
 #### Check for False-Positives (Content That Is in Fact Crawlable)
 
 Generally, any URL that returns standard HTML, links to more [HTML mimetype pages](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), and contains little-to-no non-HTML content, is crawlable. "View source" from your browser of choice will help see what the crawler itself is seeing. If in fact the data can be crawled, nominate it to the Internet Archive using the [EDGI Nomination Chrome Extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok), click the `Do not harvest` checkbox in the Research section of the Archivers app, click `Checkin this URL`, and move on to another URL.
+
+A written guide on using the Chrome Nomination tool, the EDGI Primer Database, and a video tutorial are available [in Seeders' Documentation](seeding/#crawlable-urls). 
 
 #### Some Things to Think About While Reviewing a URL
 

--- a/docs/researching.md
+++ b/docs/researching.md
@@ -30,7 +30,7 @@ Researchers review "uncrawlables" identified during [Seeding](seeding.md), confi
 
 <div class = "note">
   <strong>Using Archivers App</strong> <br />  
-  Review our walkthrough video below and refer to the <a href="/faq/">FAQ</a> for any additional questions about the <a href="http://www.archivers.space" target="_blank">Archivers app</a><!---_--->. <br />
+  Review our walkthrough video below and refer to the <a href="/faq/">FAQ</a> for any additional questions about the <a href="http://www.archivers.space" target="_blank">Archivers app</a><!--_-->. <br />
   &nbsp;<br />
   <p style="text-align:center"><iframe width="80%" height="315" src="https://www.youtube.com/embed/tvSSILnHnpA" frameborder="0" allowfullscreen></iframe></p>
 </div>
@@ -57,6 +57,7 @@ Again, see [EDGI's Guides](https://edgi-govdata-archiving.github.io/guides/) for
 
 -   [Understanding the Internet Archive Web Crawler](https://edgi-govdata-archiving.github.io/guides/internet-archive-crawler/)
 -   [Seeding the Internet Archive’s Web Crawler](https://edgi-govdata-archiving.github.io/guides/seeding-internet-archive/)
+-   A written guide on using the Chrome Nomination tool, the EDGI Primer Database, and a video tutorial are available [in Seeders' Documentation](seeding/#crawlable-urls)
 
 Some additional technical notes for answering this:
 

--- a/docs/seeding.md
+++ b/docs/seeding.md
@@ -23,7 +23,9 @@ Seeders use the [EDGI Archiving Primers](https://envirodatagov.org/archiving/), 
 
 - URLs judged to be crawlable are nominated ("seeded") to the Internet Archive, using the [EDGI Nomination Chrome extension](https://chrome.google.com/webstore/detail/nominationtool/abjpihafglmijnkkoppbookfkkanklok?hl=en).
 
-**Wherever possible, add in the Agency Office Code from the sub-primer.** Talk to the DataRescue organizers to learn more.
+To learn more about nominating URLs, refer to [this Google Doc](https://docs.google.com/document/d/1L_JYldCwCHxVEW_9nD6llWPtbh_VvPwp2UYE6cGE2g0/edit), watch this [training video on Agency Primers and EOT](https://youtu.be/Ro-f58Cecdg) or talk to the DataRescue organizers.
+
+**Wherever possible, add in the Agency Office Code from the [sub-primer database](https://envirodatagov.org/event-toolkit/primers-database/).** 
 
 ### Uncrawlable URLs
 


### PR DESCRIPTION
The current workflow points to using the Chrome tool for nominating content for Internet Archive Web Crawling in a few different places. However, there don't seem to yet be resources for how to fill in information in the tool, and work with the EDGI Primer database. 

This PR links a video tutorial on Agency Primers (this should address issue #96 ), a Google Doc about how to nominate URLs, and to the Agency Primers database itself. It does so in 3 places where we ran into this issue at a local DataRescue event - the seeders file contains the main reference, while the researchers and harvester files have been updated in sections where it is suggested to check for false positives, and links back to the seeders page. 
